### PR TITLE
Add conditions that create a Critical notification

### DIFF
--- a/check_snmp_apc_ups_state.sh
+++ b/check_snmp_apc_ups_state.sh
@@ -173,8 +173,6 @@ declare -a vFlags=(
 "Flag 60: Minor or Environment Alarm") 
 
 
-vFlag1=$( echo $vOIDOut |  awk '{print substr($0,0,1)}' )
-
 vFlagsStr=""
 vIndex=0
 for vFlag in "${vFlags[@]}"; do
@@ -186,14 +184,22 @@ for vFlag in "${vFlags[@]}"; do
   let vIndex=${vIndex}+1
 done
 
+vCritical=0
+vOIDArray=($(echo $vOIDOut|sed  's/\(.\)/\1 /g'))
+for i in "${vOIDArray[0]}" "${vOIDArray[1]}" "${vOIDArray[2]}" "${vOIDArray[4]}" "${vOIDArray[8]}" "${vOIDArray[10]}" "${vOIDArray[11]}" "${vOIDArray[12]}" "${vOIDArray[13]}" "${vOIDArray[14]}" "${vOIDArray[15]}" "${vOIDArray[17]}" "${vOIDArray[20]}" "${vOIDArray[23]}" "${vOIDArray[24]}" "${vOIDArray[25]}" "${vOIDArray[26]}" "${vOIDArray[27]}" "${vOIDArray[29]}" "${vOIDArray[32]}" "${vOIDArray[36]}" "${vOIDArray[37]}" "${vOIDArray[38]}" "${vOIDArray[39]}" "${vOIDArray[40]}" "${vOIDArray[41]}" "${vOIDArray[42]}" "${vOIDArray[43]}" "${vOIDArray[44]}" "${vOIDArray[45]}" "${vOIDArray[46]}" "${vOIDArray[47]}" "${vOIDArray[48]}" "${vOIDArray[49]}" "${vOIDArray[52]}" "${vOIDArray[53]}" "${vOIDArray[54]}" "${vOIDArray[55]}" "${vOIDArray[59]}"; do 
+  let vCritical+=$i
+done
+
 #
 # Icinga Check Plugin output
 #
-if [ "$vFlag1" -eq "1" ]; then
-    echo -e "APC UPS State CRITICAL \nCurrent active flags:$vFlagsStr"
-    exit $codeCRITICAL
-elif [ "$vFlag1" -eq "0" ]; then
-    echo -e "APC UPS State OK \nCurrent active flags:$vFlagsStr"
-    exit $codeOK
+if [ "$vCritical" -eq "0" ]; then
+  echo -e "APC UPS State OK \nCurrent active flags:$vFlagsStr"
+  exit $codeOK
+elif [ "$vCritical" -ne "0" ]; then
+  echo -e "APC UPS State CRITICAL \nCurrent active flags:$vFlagsStr"
+  exit $codeCRITICAL
+else
+  echo -e "APC UPS State UNKNOWN \nCurrent active flags:$vFlagsStr"
+  exit $codeUNKNOWN
 fi
-exit $codeUNKNOWN


### PR DESCRIPTION
The original code only triggered a critical in the event that Flag 1 was
not zero. However, in my tests with the UPS on battery Flag 1 remained
zero. I added a section to test for all conditions that I felt like
should be considered critical.

The following conditions should trigger a critical alert:

Flag 01: Abnormal Condition Present
Flag 02: On Battery
Flag 03: Low Battery
Flag 05: Replace Battery
Flag 09: Overload
Flag 11: Batteries Discharged
Flag 12: Manual Bypass
Flag 13: Software Bypass
Flag 14: In Bypass due to Internal Fault
Flag 15: In Bypass due to Supply Failure
Flag 16: In Bypass due to Fan Failure
Flag 18: Sleeping until Utility Power Returns
Flag 21: Battery Communication Lost
Flag 24: Bad Output Voltage
Flag 25: Battery Charger Failure
Flag 26: High Battery Temperature
Flag 27: Warning Battery Temperature
Flag 28: Critical Battery Temperature
Flag 30: Low Battery / On Battery
Flag 33: No Batteries Attached
Flag 37: Inverter DC Imbalance
Flag 38: Transfer Relay Failure
Flag 39: Shutdown or Unable to Transfer
Flag 40: Low Battery Shutdown
Flag 41: Electronic Unit Fan Failure
Flag 42: Main Relay Failure
Flag 43: Bypass Relay Failure
Flag 44: Temporary Bypass
Flag 45: High Internal Temperature
Flag 46: Battery Temperature Sensor Fault
Flag 47: Input Out of Range for Bypass
Flag 48: DC Bus Overvoltage
Flag 49: PFC Failure
Flag 50: Critical Hardware Fault
Flag 53: Emergency Power Off (EPO) Activated
Flag 54: Load Alarm Violation
Flag 55: Bypass Phase Fault
Flag 56: UPS Internal Communication Failure
Flag 60: Minor or Environment Alarm